### PR TITLE
Relax faraday ver req

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    greenhouse_api (0.1.10)
-      faraday (~> 1.1)
+    greenhouse_api (0.1.11)
+      faraday (~> 0.15)
 
 GEM
   remote: https://rubygems.org/
@@ -11,9 +11,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     crack (0.4.4)
     diff-lcs (1.4.4)
-    faraday (1.1.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
     hashdiff (1.0.1)
     multipart-post (2.1.1)
     public_suffix (4.0.6)
@@ -30,7 +29,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
-    ruby2_keywords (0.0.2)
     vcr (6.0.0)
     webmock (3.10.0)
       addressable (>= 2.3.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     greenhouse_api (0.1.11)
-      faraday (~> 0.15)
+      faraday (>= 0.15.4)
 
 GEM
   remote: https://rubygems.org/

--- a/greenhouse_api.gemspec
+++ b/greenhouse_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '~> 0.15'
+  spec.add_dependency "faraday", '>= 0.15.4'
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "vcr", "~> 6"
   spec.add_development_dependency "webmock", "~> 3.10"

--- a/greenhouse_api.gemspec
+++ b/greenhouse_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", '~> 1.1'
+  spec.add_dependency "faraday", '~> 0.15'
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "vcr", "~> 6"
   spec.add_development_dependency "webmock", "~> 3.10"

--- a/lib/greenhouse_api/version.rb
+++ b/lib/greenhouse_api/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseApi
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end


### PR DESCRIPTION
Allow minimum version to be `0.15.4` so the gem can be more easily adopted